### PR TITLE
ISSUE: add build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A NonEuclidean rendering engine for Windows, written in C++ OpenGL.
 To see what this code is about, check out this video:
 https://youtu.be/kEB11PQ9Eo8
 
+
 ## Source Code Dependencies
 Add glew-2.1.0 to the main directory
 


### PR DESCRIPTION
I'm opening a pull request because you've disabled issues

Could you please add build instructions as I cant make it work (macOS)

Compiler invocation: `g++-9 -I/usr/local/include -L/usr/local/lib -std=c++11  -l SDL2  -l GLEW.2.1 -l AntTweakBar -l sfml-graphics *.cpp`

```
Undefined symbols for architecture x86_64:
  "_glBegin", referenced from:
      Collider::DebugDraw(Camera const&, Matrix4 const&) in cc3ttfF3.o
  "_glBindTexture", referenced from:
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      FrameBuffer::Use()      in ccN8x0VM.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
      Texture::Use()     in cceK1QYo.o
  "_glClear", referenced from:
      Engine::Render(Camera const&, unsigned int, Portal const*) in cckvl5Ql.o
  "_glClearColor", referenced from:
      Engine::InitGLObjects()      in cckvl5Ql.o
  "_glColor3f", referenced from:
      Collider::DebugDraw(Camera const&, Matrix4 const&) in cc3ttfF3.o
  "_glColorMask", referenced from:
      Engine::Render(Camera const&, unsigned int, Portal const*) in cckvl5Ql.o
  "_glCullFace", referenced from:
      Engine::InitGLObjects()      in cckvl5Ql.o
  "_glDepthFunc", referenced from:
      Collider::DebugDraw(Camera const&, Matrix4 const&) in cc3ttfF3.o
      Engine::InitGLObjects()      in cckvl5Ql.o
  "_glDepthMask", referenced from:
      Sky::Draw(Camera const&) in cckvl5Ql.o
      Engine::Render(Camera const&, unsigned int, Portal const*) in cckvl5Ql.o
      Engine::InitGLObjects()      in cckvl5Ql.o
  "_glDrawArrays", referenced from:
      Mesh::Draw()     in cc318r6Y.o
  "_glEnable", referenced from:
      Engine::InitGLObjects()      in cckvl5Ql.o
  "_glEnd", referenced from:
      Collider::DebugDraw(Camera const&, Matrix4 const&) in cc3ttfF3.o
  "_glGenTextures", referenced from:
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
  "_glTexImage2D", referenced from:
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
  "_glTexParameteri", referenced from:
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      FrameBuffer::FrameBuffer() in ccN8x0VM.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
      Texture::Texture(char const*, int, int) in cceK1QYo.o
  "_glVertex4f", referenced from:
      Collider::DebugDraw(Camera const&, Matrix4 const&) in cc3ttfF3.o
  "_glViewport", referenced from:
      Camera::UseViewport() const in ccZWpU5G.o
      FrameBuffer::Render(Camera const&, unsigned int, Portal const*) in ccN8x0VM.o
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
```
